### PR TITLE
refactor: 重构DNS查询逻辑，使用subprocess调用dig命令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ cython_debug/
 .DS_Store
 *.txt
 !requirements.txt
+test.py
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 - 自动收集子域名信息
 - 实时显示检测进度
 - 将检测结果保存到文件
+- 支持从文件读取域名列表
+- 支持macOS、Linux
 
 ## 安装
 
@@ -29,8 +31,6 @@ pip install -U uv
 ```bash
 uv venv venv
 source venv/bin/activate  # Linux/macOS
-# 或者在Windows上使用：
-# venv\Scripts\activate
 ```
 
 然后使用uv安装项目依赖：


### PR DESCRIPTION
重构了get_nameservers和test_zone_transfer函数，使用subprocess模块调用dig命令进行DNS查询，以提高代码的可维护性和跨平台兼容性。同时更新了.gitignore和README.md文件，添加了新的忽略规则和功能说明。